### PR TITLE
FIX: campo hacerlo requerido solo a nivel de vistas y cuando sean bodegas internas

### DIFF
--- a/models/stock_picking.py
+++ b/models/stock_picking.py
@@ -209,7 +209,7 @@ class StockLocation(models.Model):
     sii_document_class_id = fields.Many2one(
             'sii.document_class',
             string='Document Type',
-            required=True,
+            required=False,
         )
     sequence_id = fields.Many2one(
             'ir.sequence',

--- a/views/stock_picking.xml
+++ b/views/stock_picking.xml
@@ -136,7 +136,7 @@
                 <field name="usage" position="after">
                     <field name="sii_code"/>
                     <field name="sequence_id"/>
-                    <field name="sii_document_class_id" />
+                    <field name="sii_document_class_id" attrs="{'required': [('usage','=','internal')]}"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Esta es la solucion para el error #13 
Antes al actualizar salia error en el log yno permitia crear bodegas tipo cliente o proveedor sin llenar el campo sii_document_class_id, despues del cambio, este campo solo es requerido en las bodegas internas

Requerido en ubicaciones internas
![image](https://user-images.githubusercontent.com/7775116/35882690-ff544bf0-0b52-11e8-8480-b4a08fc5bd9d.png)

No requerido en bodegas de proveedor o cliente, solo internas
![image](https://user-images.githubusercontent.com/7775116/35882723-19d363c6-0b53-11e8-95b4-c671e51a2faa.png)

